### PR TITLE
Fix notes duplication in container

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,6 @@ for (let x = 0; x < urlKeys.length; x++) {
 }
 
 heading.style.display = "none";
-showAllNotes();
 container.style.display = "none";
 
 checkbox.addEventListener("change", () => {
@@ -269,6 +268,7 @@ function isSubstring(s1, s2) {
 
 function hideAllNotes() {
   container.style.display = "none";
+  container.innerHTML = "";
 }
 
 function hideList() {


### PR DESCRIPTION
Fixed notes duplication in container after clicking "Show all notes" checkbox multiple times