### PR TITLE
Add protocols in websites list

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ var urlMap = new Map();
 
 for (let x = 0; x < urlKeys.length; x++) {
   var tempUrl = new URL(urlKeys[x]);
-  var key = tempUrl.hostname;
+  var key = tempUrl.hostname || tempUrl.protocol.slice(0, -1);
 
   if (urlMap.has(key)) {
     var fetchedArr = urlMap.get(key);


### PR DESCRIPTION
**Situation:** Used page pad while taking notes in a local pdf file with the address file:///loc/to/pdf.
**Problem:** Website button in websites list can't be found.
**Fix:** Showing protocol in websites list instead
**E.g.** file:///loc/to/pdf -> file

![image](https://user-images.githubusercontent.com/17378596/126091681-d1a4f3ec-4184-4f29-a19e-2d5912f899d7.png)

**Before:**
![image](https://user-images.githubusercontent.com/17378596/126091720-a8519ac6-b48b-45fd-a17d-8769af4577ef.png)

**After:**
![image](https://user-images.githubusercontent.com/17378596/126091909-f732a59d-74e8-400b-b5f7-5970cd18f0cb.png)

