### PR TITLE
Fix local file access

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,12 +71,19 @@ function clearResult() {
 
 function displayNotesInDOM(tabTitle, tabNote, url) {
   const noteTab = document.createElement("details");
+  const tempUrl = new URL(url);
   noteTab.className = "all-notes-tab";
   noteTab.innerHTML = `
             <summary class="summary-heading">${tabTitle}</summary>
             <div class="readonly">${tabNote}</div>
             <div class="ctrl-div"><a class="visit" target="_blank" href=${url}>VISIT THIS PAGE</a><button id="${url}" class="delete-btn"><img src="/img/trash.png"></button></div>
           `;
+  if (!tempUrl.hostname){
+    const visit = noteTab.querySelector('.visit');
+    visit.addEventListener('click', () => { 
+      chrome.tabs.create({url: url})
+    });
+  }
   return noteTab;
 }
 


### PR DESCRIPTION
**Situation:** Used page pad while taking notes in a local pdf file with the address file:///loc/to/pdf.
**Issue:** Cannot revisit the local pdf file via index.html 
![image](https://user-images.githubusercontent.com/17378596/126189881-aa4f1d1f-a92d-4bb1-a4db-11446e81d0ac.png)

**Fix:** If no hostname in url then add an eventListener on "Visit this page" button and use chrome.tabs.create to bypass the error above.
**Note:** The error still clutters the console log but won't affect the program. We can omit the error by removing the href attribute and adding a style cursor: pointer; to the visit button. Let me know what you think. 