### PR TITLE
Remove outline in text-box and search-input

### DIFF
--- a/index.css
+++ b/index.css
@@ -79,6 +79,7 @@ body {
   background: #f8f8f8;
   box-shadow: inset 0px 6px 10px rgba(0, 0, 0, 0.08);
   padding: 10px;
+  outline: none;
 }
 .input {
   color: #747474;

--- a/style.css
+++ b/style.css
@@ -60,6 +60,7 @@ body {
     Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   border: 3px solid var(--color-theme);
   box-shadow: 0px 20px 20px 5px rgba(0, 0, 0, 0.06);
+  outline: none;
 }
 trix-editor {
   color: white;


### PR DESCRIPTION
Consider removing outlines in search and popup text box? 

Before:
![before search](https://user-images.githubusercontent.com/17378596/127258446-b37ce5be-f875-4a9b-b38b-3d89edbb73e2.gif)
![before text-box](https://user-images.githubusercontent.com/17378596/127258461-f2c8086f-2b3a-40e4-b47f-fa3e50c11f6c.gif)

After:
![after search](https://user-images.githubusercontent.com/17378596/127258506-c1bafb70-4ffe-4b7d-b046-965d07e1ad3a.gif)
![after text-box](https://user-images.githubusercontent.com/17378596/127258517-4ba67c8f-afb3-44ba-a9e9-bee92e2c5ae3.gif)



